### PR TITLE
fix: add TTL-based cleanup for stale enqueueStates entries

### DIFF
--- a/internal/controller/promotionstrategy_controller.go
+++ b/internal/controller/promotionstrategy_controller.go
@@ -369,6 +369,8 @@ func (r *PromotionStrategyReconciler) enqueueOutOfSyncCTPs(ctx context.Context, 
 		return ctp.Status.Proposed.Dry.Sha
 	}
 
+	now := time.Now()
+
 	// Helper to get or create state for a CTP (must be called with lock held)
 	getOrCreateState := func(key client.ObjectKey) *ctpEnqueueState {
 		state := r.enqueueStates[key]
@@ -403,8 +405,6 @@ func (r *PromotionStrategyReconciler) enqueueOutOfSyncCTPs(ctx context.Context, 
 
 	// Trigger reconcile only for CTPs that have a different effective dry SHA.
 	// Rate limiting: Only enqueue if not enqueued recently.
-	now := time.Now()
-
 	for _, ctp := range ctps {
 		effectiveSha := getEffectiveDrySha(ctp)
 		if effectiveSha == targetSha {
@@ -473,6 +473,29 @@ func (r *PromotionStrategyReconciler) enqueueOutOfSyncCTPs(ctx context.Context, 
 
 		if r.EnqueueCTP != nil {
 			r.EnqueueCTP(ctp.Namespace, ctp.Name)
+		}
+	}
+
+	// Clean up stale entries from enqueueStates map to prevent memory leaks.
+	// Uses TTL-based cleanup - entries not accessed recently are removed.
+	r.cleanupStaleEnqueueStates(now)
+}
+
+// cleanupStaleEnqueueStates removes entries from the enqueueStates map that
+// haven't been enqueued within the TTL period. This ensures cleanup only happens
+// for CTPs that are no longer being reconciled (i.e., deleted from Kubernetes),
+// rather than just not in a particular PromotionStrategy's current list.
+func (r *PromotionStrategyReconciler) cleanupStaleEnqueueStates(now time.Time) {
+	// TTL for stale entries - entries not enqueued in this duration are removed.
+	// This should be longer than the rate limit threshold to avoid premature cleanup.
+	const stateTTL = 1 * time.Hour
+
+	r.enqueueStateMutex.Lock()
+	defer r.enqueueStateMutex.Unlock()
+
+	for key, state := range r.enqueueStates {
+		if now.Sub(state.lastEnqueueTime) > stateTTL {
+			delete(r.enqueueStates, key)
 		}
 	}
 }

--- a/internal/controller/promotionstrategy_controller_test.go
+++ b/internal/controller/promotionstrategy_controller_test.go
@@ -4391,5 +4391,50 @@ var _ = Describe("PromotionStrategy Bug Tests", func() {
 			Expect(secondCount).To(Equal(2), "only ctp-2 should have enqueued in second call")
 			Expect(lastEnqueuedName).To(Equal("ctp-2"), "ctp-2 should be the last enqueued")
 		})
+
+		It("should clean up stale entries based on TTL", func() {
+			reconciler, enqueuedCTPs, enqueueMutex := makeReconciler()
+
+			ctx := context.Background()
+			ctp1 := makeCTP("ctp-1")
+			ctp2 := makeCTP("ctp-2")
+			ctp3 := makeCTP("ctp-3")
+
+			// First call with all three CTPs
+			reconciler.enqueueOutOfSyncCTPs(ctx, []*promoterv1alpha1.ChangeTransferPolicy{ctp1, ctp2, ctp3})
+			enqueueMutex.Lock()
+			firstCount := len(*enqueuedCTPs)
+			enqueueMutex.Unlock()
+			Expect(firstCount).To(Equal(3), "all three CTPs should enqueue")
+
+			// Verify all three have state entries with recent lastEnqueueTime
+			reconciler.enqueueStateMutex.Lock()
+			Expect(reconciler.enqueueStates).To(HaveLen(3), "should have 3 state entries")
+
+			// Manually set ctp-2 and ctp-3 to have old lastEnqueueTime (simulating deleted CTPs)
+			oldTime := time.Now().Add(-2 * time.Hour) // Older than 1 hour TTL
+			reconciler.enqueueStates[client.ObjectKey{Namespace: "test-ns", Name: "ctp-2"}].lastEnqueueTime = oldTime
+			reconciler.enqueueStates[client.ObjectKey{Namespace: "test-ns", Name: "ctp-3"}].lastEnqueueTime = oldTime
+			reconciler.enqueueStateMutex.Unlock()
+
+			// Wait past the rate limit threshold so ctp-1 will enqueue again
+			time.Sleep(16 * time.Second)
+
+			// Call with ctp-1 only - this updates ctp-1's lastEnqueueTime and triggers cleanup
+			reconciler.enqueueOutOfSyncCTPs(ctx, []*promoterv1alpha1.ChangeTransferPolicy{ctp1})
+
+			// Verify stale entries were cleaned up based on TTL
+			reconciler.enqueueStateMutex.Lock()
+			stateCount := len(reconciler.enqueueStates)
+			_, hasCtp1 := reconciler.enqueueStates[client.ObjectKey{Namespace: "test-ns", Name: "ctp-1"}]
+			_, hasCtp2 := reconciler.enqueueStates[client.ObjectKey{Namespace: "test-ns", Name: "ctp-2"}]
+			_, hasCtp3 := reconciler.enqueueStates[client.ObjectKey{Namespace: "test-ns", Name: "ctp-3"}]
+			reconciler.enqueueStateMutex.Unlock()
+
+			Expect(stateCount).To(Equal(1), "should only have 1 state entry after TTL cleanup")
+			Expect(hasCtp1).To(BeTrue(), "ctp-1 should still have state (recently enqueued)")
+			Expect(hasCtp2).To(BeFalse(), "ctp-2 state should be cleaned up (TTL expired)")
+			Expect(hasCtp3).To(BeFalse(), "ctp-3 state should be cleaned up (TTL expired)")
+		})
 	})
 })


### PR DESCRIPTION
The enqueueStates map was growing unboundedly as CTPs were tracked for rate limiting. When CTPs were deleted from Kubernetes, their entries remained in the map indefinitely.

This fix uses TTL-based cleanup with the existing lastEnqueueTime field:
- Entries not enqueued within 1 hour are removed
- This ensures cleanup only happens for CTPs that are no longer being reconciled (i.e., deleted from Kubernetes)
- No new fields needed - reuses lastEnqueueTime

Also adds test to verify TTL-based cleanup behavior.