### PR TITLE
Add vars expression to WhenWithOutputSpec to eliminate logic duplication

### DIFF
--- a/api/v1alpha1/webrequestcommitstatus_types.go
+++ b/api/v1alpha1/webrequestcommitstatus_types.go
@@ -177,8 +177,24 @@ type TriggerModeSpec struct {
 	Response *ResponseOutputSpec `json:"response,omitempty"`
 }
 
-// WhenWithOutputSpec holds a when condition (boolean expression) and optional output (map expression).
+// WhenWithOutputSpec holds a when condition (boolean expression), optional shared vars, and optional output (map expression).
 type WhenWithOutputSpec struct {
+	// Vars optionally holds an expression that is evaluated first and whose map keys are injected as
+	// additional top-level variables into both Expression and Output.Expression. Use it to compute a
+	// value once and refer to it in both the condition and the output without duplicating logic.
+	//
+	// Available variables are the same as for Expression (see below). Must return a map/object.
+	//
+	// Examples:
+	//   # Compute the proposed SHA once, use in both condition and output
+	//   - "{ proposedSha: find(PromotionStrategy.Status.Environments, {.Branch == Branch}).Proposed.Hydrated.Sha }"
+	//
+	//   # Compute a derived flag and a value together
+	//   - "{ env: find(PromotionStrategy.Status.Environments, {.Branch == Branch}), attempt: (TriggerOutput[\"attempt\"] ?? 0) + 1 }"
+	//
+	// +optional
+	Vars *OutputSpec `json:"vars,omitempty"`
+
 	// Expression is a boolean expr expression that decides whether the HTTP request should be made.
 	// It is evaluated BEFORE each potential HTTP request. When it returns true the request is made;
 	// when false the controller keeps the previous phase and skips the request.
@@ -191,6 +207,7 @@ type WhenWithOutputSpec struct {
 	//   - TriggerOutput (map[string]any): custom data from the previous when.output.expression evaluation
 	//   - ResponseOutput (map[string]any): response data from the previous HTTP request (if any)
 	//   - SuccessOutput (map[string]any): custom data from the previous success.when.output.expression evaluation
+	//   - Any keys returned by Vars.Expression (injected as top-level variables)
 	//
 	// Note: PromotionStrategy.Status.Environments is an ordered array representing the promotion sequence.
 	// Use Branch + filter/find to look up environment-specific data:
@@ -200,8 +217,8 @@ type WhenWithOutputSpec struct {
 	//   # Always trigger (equivalent to polling mode)
 	//   - "true"
 	//
-	//   # Only trigger when SHA changes from what we last tracked
-	//   - "find(PromotionStrategy.Status.Environments, {.Branch == Branch}).Proposed.Hydrated.Sha != (TriggerOutput['lastCheckedSha'] ?? '')"
+	//   # Only trigger when SHA changes from what we last tracked (use Vars to avoid repeating the find())
+	//   - "proposedSha != (TriggerOutput['lastCheckedSha'] ?? '')"
 	//
 	//   # Only trigger when a particular commit status is success (e.g. argocd-health)
 	//   - "let env = find(PromotionStrategy.Status.Environments, {.Branch == Branch}); any(env.Proposed.CommitStatuses, {.Key == 'argocd-health' && .Phase == 'success'})"
@@ -218,11 +235,12 @@ type WhenWithOutputSpec struct {
 	// and is available in the next reconcile as TriggerOutput in when.expression, when.output.expression, and in templates.
 	// Use it to track state such as attempt counts, last-seen SHAs, or timestamps.
 	//
-	// Variables are the same as for Expression (see above). The expression must return a map/object; every key is stored in TriggerOutput.
+	// Variables are the same as for Expression (see above), including any keys from Vars.Expression.
+	// The expression must return a map/object; every key is stored in TriggerOutput.
 	//
 	// Examples:
-	//   # Track SHA to detect changes
-	//   - "{ trackedSha: find(PromotionStrategy.Status.Environments, {.Branch == Branch}).Proposed.Hydrated.Sha }"
+	//   # Track SHA to detect changes (proposedSha comes from Vars.Expression)
+	//   - "{ trackedSha: proposedSha }"
 	//
 	//   # Increment attempt counter
 	//   - "{ attemptCount: (TriggerOutput[\"attemptCount\"] ?? 0) + 1 }"

--- a/docs/commit-status-controllers/web-request.md
+++ b/docs/commit-status-controllers/web-request.md
@@ -54,8 +54,10 @@ Uses expressions to dynamically control when HTTP requests are made. Powerful fo
 **Behavior:**
 - Evaluates trigger expression on each reconciliation
 - Only makes HTTP request if trigger expression returns true
+- Can compute shared sub-expressions once via `trigger.when.vars` (available in both `when.expression` and `when.output.expression`)
 - Can store and access custom state via `TriggerOutput` (via `trigger.when.output.expression`)
 - Can access previous HTTP response data via `ResponseOutput` (via `response.output.expression`)
+- Can compute shared sub-expressions once via `success.when.vars` (available in both `success.when.expression` and `success.when.output.expression`)
 - Can store and access custom state from success evaluation via `SuccessOutput` (via `success.when.output.expression`)
 - Always reconciles at `requeueDuration` interval (default: 1 minute)
 
@@ -99,6 +101,44 @@ The `success.when.expression` is evaluated **every reconcile**, regardless of wh
 | `TriggerOutput` | map[string]any | Custom data from the previous `when.output.expression` evaluation (trigger mode only). |
 | `ResponseOutput` | map[string]any | Response data from the previous HTTP request's `response.output.expression` (trigger mode only). |
 | `SuccessOutput` | map[string]any | Custom data from the previous `success.when.output.expression` evaluation. |
+
+### Shared variables with `vars`
+
+Both `trigger.when` and `success.when` support an optional `vars` field — a map expression evaluated **before** the `expression` and `output.expression`. Its keys are injected as top-level variables, so you can compute a value once and reference it in both the condition and the output without duplicating logic.
+
+**`trigger.when.vars`** — variables available to `trigger.when.expression` and `trigger.when.output.expression`:
+
+```yaml
+trigger:
+  when:
+    vars:
+      expression: |
+        { proposedSha: find(PromotionStrategy.Status.Environments, {.Branch == Branch}).Proposed.Hydrated.Sha }
+    expression:  |
+      proposedSha != (TriggerOutput["trackedSha"] ?? "")
+    output:
+      expression: |
+        { trackedSha: proposedSha }
+```
+
+Without `vars`, both expressions would repeat the `find(…).Proposed.Hydrated.Sha` call. With `vars`, it is computed once and referenced as `proposedSha`.
+
+**`success.when.vars`** — variables available to `success.when.expression` and `success.when.output.expression`:
+
+```yaml
+success:
+  when:
+    vars:
+      expression: |
+        { isApproved: Response != nil && Response.StatusCode == 200 && Response.Body.approved == true }
+    expression: |
+      isApproved
+    output:
+      expression: |
+        { capturedApproval: isApproved, reviewer: Response != nil ? Response.Body.reviewer : "" }
+```
+
+The `vars` expression receives the same variables as the `expression` field — including `Response` in the success context.
 
 > [!IMPORTANT]
 > Since the expression runs every reconcile, it must handle `Response` being `nil` (no HTTP request this reconcile). Expressions that only reference `Response.*` will error when `Response` is `nil`, causing the reconcile to return an error and requeue. Guard `Response` access:
@@ -293,7 +333,7 @@ stringData:
 
 ### Trigger Mode - SHA Change Detection
 
-Only make HTTP requests when the SHA changes, avoiding redundant calls:
+Only make HTTP requests when the SHA changes, avoiding redundant calls. Use `trigger.when.vars` to compute the SHA once and reference it from both the trigger expression and the output, instead of duplicating the `find()` call:
 
 ```yaml
 apiVersion: promoter.argoproj.io/v1alpha1
@@ -315,9 +355,12 @@ spec:
     trigger:
       requeueDuration: 1m
       when:
-        expression: 'find(PromotionStrategy.Status.Environments, {.Branch == Branch}).Proposed.Hydrated.Sha != (TriggerOutput["lastCheckedSha"] ?? "")'
+        vars:
+          expression: |
+            { proposedSha: find(PromotionStrategy.Status.Environments, {.Branch == Branch}).Proposed.Hydrated.Sha }
+        expression: 'proposedSha != (TriggerOutput["lastCheckedSha"] ?? "")'
         output:
-          expression: '{ lastCheckedSha: find(PromotionStrategy.Status.Environments, {.Branch == Branch}).Proposed.Hydrated.Sha }'
+          expression: '{ lastCheckedSha: proposedSha }'
 ```
 
 ### Trigger Mode - Only when another commit status is success
@@ -765,11 +808,14 @@ spec:
     trigger:
       requeueDuration: 1m
       when:
+        vars:
+          expression: |
+            { proposedSha: find(PromotionStrategy.Status.Environments, {.Branch == Branch}).Proposed.Hydrated.Sha }
         expression: |
-          find(PromotionStrategy.Status.Environments, {.Branch == Branch}).Proposed.Hydrated.Sha != (TriggerOutput["lastCheckedSha"] ?? "") || Phase != "success"
+          proposedSha != (TriggerOutput["lastCheckedSha"] ?? "") || Phase != "success"
         output:
           expression: |
-            { lastCheckedSha: find(PromotionStrategy.Status.Environments, {.Branch == Branch}).Proposed.Hydrated.Sha }
+            { lastCheckedSha: proposedSha }
 ```
 
 How it works:

--- a/internal/controller/webrequestcommitstatus_controller.go
+++ b/internal/controller/webrequestcommitstatus_controller.go
@@ -728,6 +728,13 @@ func (r *WebRequestCommitStatusReconciler) fireOrCarryForward(
 
 	// Run success.when even without a request, passing Response=nil.
 	exprData := successWhenExprData(td, nil)
+
+	// Evaluate success vars first; merge into exprData so both success.when and success.when.output share them.
+	exprData, err := r.applySuccessVars(ctx, wrcs, exprData)
+	if err != nil {
+		return httpValidationResult{}, err
+	}
+
 	phase, phasePerBranch, err := r.evaluateSuccessPhase(ctx, wrcs, exprData)
 	if err != nil {
 		return httpValidationResult{}, fmt.Errorf("failed to evaluate success.when expression: %w", err)
@@ -776,13 +783,25 @@ func (r *WebRequestCommitStatusReconciler) evaluateTriggerDecision(
 	}
 
 	if mode.Trigger != nil {
-		tr, err := r.evaluateTriggerExpression(ctx, mode.Trigger.When.Expression, td)
+		// Build the expression environment once so vars, expression, and output all share the same base.
+		exprData := td.triggerExprData()
+
+		// Evaluate vars first; merge results into exprData so both expression and output can use them.
+		if mode.Trigger.When.Vars != nil && mode.Trigger.When.Vars.Expression != "" {
+			varsData, err := r.evaluateVarsExpression(ctx, "triggervars", mode.Trigger.When.Vars.Expression, exprData)
+			if err != nil {
+				return triggerDecision{}, fmt.Errorf("failed to evaluate trigger vars expression: %w", err)
+			}
+			exprData = mergeVars(exprData, varsData)
+		}
+
+		tr, err := r.evaluateTriggerExpression(ctx, mode.Trigger.When.Expression, exprData)
 		if err != nil {
 			return triggerDecision{}, fmt.Errorf("failed to evaluate trigger expression: %w", err)
 		}
 		shouldFire = tr.Trigger
 		if mode.Trigger.When.Output != nil && mode.Trigger.When.Output.Expression != "" {
-			newTriggerData, err = r.evaluateTriggerDataExpression(ctx, mode.Trigger.When.Output.Expression, td)
+			newTriggerData, err = r.evaluateTriggerDataExpression(ctx, mode.Trigger.When.Output.Expression, exprData)
 			if err != nil {
 				return triggerDecision{}, fmt.Errorf("failed to evaluate trigger data expression: %w", err)
 			}
@@ -896,6 +915,13 @@ func (r *WebRequestCommitStatusReconciler) handleHTTPRequestAndValidation(ctx co
 	}
 
 	exprData := successWhenExprData(td, &response)
+
+	// Evaluate success vars first; merge into exprData so both success.when and success.when.output share them.
+	exprData, err = r.applySuccessVars(ctx, wrcs, exprData)
+	if err != nil {
+		return httpValidationResult{}, err
+	}
+
 	phase, phasePerBranch, err := r.evaluateSuccessPhase(ctx, wrcs, exprData)
 	if err != nil {
 		return httpValidationResult{}, fmt.Errorf("failed to evaluate validation expression: %w", err)
@@ -935,6 +961,20 @@ func (r *WebRequestCommitStatusReconciler) evaluateSuccessPhase(
 		return promoterv1alpha1.CommitPhaseSuccess, nil, nil
 	}
 	return promoterv1alpha1.CommitPhasePending, nil, nil
+}
+
+// applySuccessVars evaluates success.when.vars (if configured) and merges the resulting keys into
+// exprData, returning the enriched map. Called before evaluateSuccessPhase and evaluateSuccessOutput
+// so both share the same pre-computed variables without duplicating logic.
+func (r *WebRequestCommitStatusReconciler) applySuccessVars(ctx context.Context, wrcs *promoterv1alpha1.WebRequestCommitStatus, exprData map[string]any) (map[string]any, error) {
+	if wrcs.Spec.Success.When.Vars == nil || wrcs.Spec.Success.When.Vars.Expression == "" {
+		return exprData, nil
+	}
+	varsData, err := r.evaluateVarsExpression(ctx, "successvars", wrcs.Spec.Success.When.Vars.Expression, exprData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate success vars expression: %w", err)
+	}
+	return mergeVars(exprData, varsData), nil
 }
 
 // evaluateSuccessOutput evaluates the optional success.when.output expression and returns the

--- a/internal/controller/webrequestcommitstatus_controller_test.go
+++ b/internal/controller/webrequestcommitstatus_controller_test.go
@@ -4134,6 +4134,230 @@ var _ = Describe("WebRequestCommitStatus Controller - Dry SHA Guard (PromotionSt
 	})
 })
 
+// WebRequestCommitStatus Controller - Vars Expression
+// Tests for the Vars field on WhenWithOutputSpec that lets users compute a value once and reference
+// it from both the when.expression and the when.output.expression without duplicating logic.
+var _ = Describe("WebRequestCommitStatus Controller - Vars Expression", Ordered, func() {
+	var (
+		varsCtx               context.Context
+		varsName              string
+		varsScmSecret         *corev1.Secret
+		varsScmProvider       *promoterv1alpha1.ScmProvider
+		varsGitRepo           *promoterv1alpha1.GitRepository
+		varsPromotionStrategy *promoterv1alpha1.PromotionStrategy
+		varsTestServer        *httptest.Server
+		varsWRCS              *promoterv1alpha1.WebRequestCommitStatus
+	)
+
+	const varsBranch = "environment/development"
+
+	BeforeAll(func() {
+		varsCtx = context.Background()
+		varsName, varsScmSecret, varsScmProvider, varsGitRepo, _, _, varsPromotionStrategy = promotionStrategyResource(varsCtx, "webrequest-vars", "default")
+
+		varsPromotionStrategy.Spec.Environments = []promoterv1alpha1.Environment{
+			{Branch: varsBranch},
+		}
+		varsPromotionStrategy.Spec.ActiveCommitStatuses = []promoterv1alpha1.CommitStatusSelector{
+			{Key: "vars-test"},
+		}
+
+		setupInitialTestGitRepoOnServer(varsCtx, varsGitRepo)
+
+		Expect(k8sClient.Create(varsCtx, varsScmSecret)).To(Succeed())
+		Expect(k8sClient.Create(varsCtx, varsScmProvider)).To(Succeed())
+		Expect(k8sClient.Create(varsCtx, varsGitRepo)).To(Succeed())
+		Expect(k8sClient.Create(varsCtx, varsPromotionStrategy)).To(Succeed())
+	})
+
+	AfterAll(func() {
+		if varsPromotionStrategy != nil {
+			_ = k8sClient.Delete(varsCtx, varsPromotionStrategy)
+		}
+		if varsGitRepo != nil {
+			_ = k8sClient.Delete(varsCtx, varsGitRepo)
+		}
+		if varsScmProvider != nil {
+			_ = k8sClient.Delete(varsCtx, varsScmProvider)
+		}
+		if varsScmSecret != nil {
+			_ = k8sClient.Delete(varsCtx, varsScmSecret)
+		}
+	})
+
+	AfterEach(func() {
+		if varsTestServer != nil {
+			varsTestServer.Close()
+			varsTestServer = nil
+		}
+		if varsWRCS != nil {
+			_ = k8sClient.Delete(varsCtx, varsWRCS)
+			varsWRCS = nil
+		}
+	})
+
+	It("trigger.when.vars injects variables into both the trigger expression and trigger output", func() {
+		// trigger.when.vars computes proposedSha once; trigger.when.expression and
+		// trigger.when.output both reference proposedSha instead of duplicating the find() call.
+		var (
+			requestCount int
+			requestMu    sync.Mutex
+		)
+
+		By("Creating a server that returns approved=true")
+		varsTestServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestMu.Lock()
+			requestCount++
+			requestMu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"approved": true})
+		}))
+
+		By("Creating WRCS with trigger.when.vars that computes proposedSha once")
+		varsWRCS = &promoterv1alpha1.WebRequestCommitStatus{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      varsName + "-trigger-vars",
+				Namespace: "default",
+			},
+			Spec: promoterv1alpha1.WebRequestCommitStatusSpec{
+				PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: varsName},
+				Key:                  "vars-test",
+				ReportOn:             constants.CommitRefActive,
+				HTTPRequest: promoterv1alpha1.HTTPRequestSpec{
+					URLTemplate: varsTestServer.URL + "/validate",
+					Method:      "GET",
+					Timeout:     metav1.Duration{Duration: 10 * time.Second},
+				},
+				Success: promoterv1alpha1.SuccessSpec{
+					When: promoterv1alpha1.WhenWithOutputSpec{
+						Expression: `Response != nil ? Response.StatusCode == 200 && Response.Body.approved == true : Phase == "success"`,
+					},
+				},
+				Mode: promoterv1alpha1.ModeSpec{
+					Trigger: &promoterv1alpha1.TriggerModeSpec{
+						RequeueDuration: metav1.Duration{Duration: 5 * time.Second},
+						When: promoterv1alpha1.WhenWithOutputSpec{
+							// vars computes proposedSha once — both expression and output reference it.
+							Vars: &promoterv1alpha1.OutputSpec{
+								Expression: `{ proposedSha: find(PromotionStrategy.Status.Environments, {.Branch == Branch}).Active.Hydrated.Sha }`,
+							},
+							Expression: `proposedSha != (TriggerOutput["trackedSha"] ?? "")`,
+							Output: &promoterv1alpha1.OutputSpec{
+								Expression: `{ trackedSha: proposedSha }`,
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(varsCtx, varsWRCS)).To(Succeed())
+
+		By("Waiting for the first trigger to fire and store trackedSha via vars")
+		Eventually(func(g Gomega) {
+			var wrcs promoterv1alpha1.WebRequestCommitStatus
+			g.Expect(k8sClient.Get(varsCtx, types.NamespacedName{Name: varsWRCS.Name, Namespace: "default"}, &wrcs)).To(Succeed())
+			g.Expect(wrcs.Status.Environments).To(HaveLen(1))
+
+			env := wrcs.Status.Environments[0]
+			g.Expect(env.Phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess))
+			g.Expect(env.TriggerOutput).NotTo(BeNil(), "trigger output should be populated via vars")
+
+			var trigData map[string]any
+			g.Expect(json.Unmarshal(env.TriggerOutput.Raw, &trigData)).To(Succeed())
+			trackedSha, ok := trigData["trackedSha"].(string)
+			g.Expect(ok).To(BeTrue(), "trackedSha should be a string")
+			g.Expect(trackedSha).NotTo(BeEmpty(), "trackedSha should be the active SHA computed by vars")
+		}, constants.EventuallyTimeout).Should(Succeed())
+
+		By("Verifying the trigger does not fire again for the same SHA")
+		requestMu.Lock()
+		countAfterFirstFire := requestCount
+		requestMu.Unlock()
+		Consistently(func(g Gomega) {
+			requestMu.Lock()
+			c := requestCount
+			requestMu.Unlock()
+			// Allow up to two extra requests per environment to account for startup races,
+			// but confirm the trigger is suppressed for the unchanged SHA.
+			g.Expect(c).To(BeNumerically("<=", countAfterFirstFire+2),
+				"trigger should not fire again when SHA is unchanged")
+		}, 10*time.Second, 2*time.Second).Should(Succeed())
+	})
+
+	It("success.when.vars injects variables into both the success expression and success output", func() {
+		// success.when.vars computes isApproved once; success.when.expression and
+		// success.when.output both reference it instead of duplicating the boolean check.
+		By("Creating a server that returns approved=true with a reviewer field")
+		varsTestServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"approved": true,
+				"reviewer": "alice",
+			})
+		}))
+
+		By("Creating WRCS with success.when.vars that computes isApproved once")
+		varsWRCS = &promoterv1alpha1.WebRequestCommitStatus{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      varsName + "-success-vars",
+				Namespace: "default",
+			},
+			Spec: promoterv1alpha1.WebRequestCommitStatusSpec{
+				PromotionStrategyRef: promoterv1alpha1.ObjectReference{Name: varsName},
+				Key:                  "vars-test",
+				ReportOn:             constants.CommitRefActive,
+				HTTPRequest: promoterv1alpha1.HTTPRequestSpec{
+					URLTemplate: varsTestServer.URL + "/validate",
+					Method:      "GET",
+					Timeout:     metav1.Duration{Duration: 10 * time.Second},
+				},
+				Success: promoterv1alpha1.SuccessSpec{
+					When: promoterv1alpha1.WhenWithOutputSpec{
+						// vars computes isApproved once — both expression and output reference it.
+						Vars: &promoterv1alpha1.OutputSpec{
+							Expression: `{ isApproved: Response != nil && Response.StatusCode == 200 && Response.Body.approved == true }`,
+						},
+						Expression: `isApproved`,
+						Output: &promoterv1alpha1.OutputSpec{
+							Expression: `{ capturedApproval: isApproved, reviewer: Response != nil ? Response.Body.reviewer : "" }`,
+						},
+					},
+				},
+				Mode: promoterv1alpha1.ModeSpec{
+					Trigger: &promoterv1alpha1.TriggerModeSpec{
+						RequeueDuration: metav1.Duration{Duration: 5 * time.Second},
+						When: promoterv1alpha1.WhenWithOutputSpec{
+							Expression: `true`,
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(varsCtx, varsWRCS)).To(Succeed())
+
+		By("Waiting for phase to become success and SuccessOutput to be populated via vars")
+		Eventually(func(g Gomega) {
+			var wrcs promoterv1alpha1.WebRequestCommitStatus
+			g.Expect(k8sClient.Get(varsCtx, types.NamespacedName{Name: varsWRCS.Name, Namespace: "default"}, &wrcs)).To(Succeed())
+			g.Expect(wrcs.Status.Environments).To(HaveLen(1))
+
+			env := wrcs.Status.Environments[0]
+			g.Expect(env.Phase).To(Equal(promoterv1alpha1.CommitPhaseSuccess),
+				"isApproved var should make success.when.expression return true")
+			g.Expect(env.SuccessOutput).NotTo(BeNil(), "success.when.output should be populated via vars")
+
+			var successData map[string]any
+			g.Expect(json.Unmarshal(env.SuccessOutput.Raw, &successData)).To(Succeed())
+			g.Expect(successData["capturedApproval"]).To(Equal(true),
+				"capturedApproval should be the isApproved value from vars")
+			g.Expect(successData["reviewer"]).To(Equal("alice"),
+				"reviewer should be extracted from response alongside the vars variable")
+		}, constants.EventuallyTimeout).Should(Succeed())
+	})
+})
+
 func wrcsPhaseForBranch(items []promoterv1alpha1.WebRequestCommitStatusPhasePerBranchItem, branch string) promoterv1alpha1.CommitStatusPhase {
 	for _, it := range items {
 		if it.Branch == branch {

--- a/internal/controller/webrequestcommitstatus_expressions.go
+++ b/internal/controller/webrequestcommitstatus_expressions.go
@@ -80,6 +80,13 @@ func (r *WebRequestCommitStatusReconciler) getCompiledTriggerDataExpression(expr
 	return r.getCompiledExpression(expressionCacheKey{Prefix: "triggerdata", Expression: expression})
 }
 
+// getCompiledVarsExpression returns a cached or newly compiled vars expression program.
+// Used by evaluateVarsExpression. Compiled without a result type constraint; the expression must return a map.
+// prefix distinguishes trigger vars ("triggervars") from success vars ("successvars") in the cache.
+func (r *WebRequestCommitStatusReconciler) getCompiledVarsExpression(prefix, expression string) (*vm.Program, error) {
+	return r.getCompiledExpression(expressionCacheKey{Prefix: prefix, Expression: expression})
+}
+
 // getCompiledValidationExpression returns a cached or newly compiled validation expression program.
 // Used by evaluateValidationExpression. Compiled with expr.AsBool() so the expression must return a boolean.
 func (r *WebRequestCommitStatusReconciler) getCompiledValidationExpression(expression string) (*vm.Program, error) {
@@ -128,9 +135,45 @@ func successWhenExprData(td templateData, resp *httpResponse) map[string]any {
 	return exprData
 }
 
+// evaluateVarsExpression runs a vars expression (trigger or success) and returns the resulting map.
+// The map keys are subsequently merged into the shared exprData so both the condition expression
+// and the output expression can reference them without duplicating logic.
+// prefix is "triggervars" or "successvars" and is used only for cache namespacing.
+func (r *WebRequestCommitStatusReconciler) evaluateVarsExpression(ctx context.Context, prefix, expression string, exprData map[string]any) (map[string]any, error) {
+	logger := log.FromContext(ctx)
+
+	program, err := r.getCompiledVarsExpression(prefix, expression)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile vars expression: %w", err)
+	}
+
+	output, err := expr.Run(program, exprData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate vars expression: %w", err)
+	}
+
+	result, ok := output.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("vars expression must return a map/object, got %T", output)
+	}
+
+	logger.V(4).Info("Vars expression evaluated", "prefix", prefix, "vars", result)
+	return result, nil
+}
+
+// mergeVars copies every key from vars into base, returning base. Keys in vars shadow same-named
+// base keys, allowing vars to override or extend the standard expression environment.
+func mergeVars(base map[string]any, vars map[string]any) map[string]any {
+	for k, v := range vars {
+		base[k] = v
+	}
+	return base
+}
+
 // evaluateTriggerExpression runs the trigger expression to decide whether to perform the HTTP request.
+// exprData is the pre-built expression environment (from triggerExprData, optionally enriched with vars).
 // Returns true when the controller should issue the request; false keeps the phase from the last reconcile and skips.
-func (r *WebRequestCommitStatusReconciler) evaluateTriggerExpression(ctx context.Context, expression string, td templateData) (triggerResult, error) {
+func (r *WebRequestCommitStatusReconciler) evaluateTriggerExpression(ctx context.Context, expression string, exprData map[string]any) (triggerResult, error) {
 	logger := log.FromContext(ctx)
 
 	program, err := r.getCompiledTriggerExpression(expression)
@@ -138,7 +181,7 @@ func (r *WebRequestCommitStatusReconciler) evaluateTriggerExpression(ctx context
 		return triggerResult{}, fmt.Errorf("failed to compile trigger expression: %w", err)
 	}
 
-	output, err := expr.Run(program, td.triggerExprData())
+	output, err := expr.Run(program, exprData)
 	if err != nil {
 		return triggerResult{}, fmt.Errorf("failed to evaluate trigger expression: %w", err)
 	}
@@ -154,7 +197,8 @@ func (r *WebRequestCommitStatusReconciler) evaluateTriggerExpression(ctx context
 
 // evaluateTriggerDataExpression runs the trigger when.output expression to produce state that is persisted
 // across reconcile cycles in status.triggerOutput. Must return a map[string]any.
-func (r *WebRequestCommitStatusReconciler) evaluateTriggerDataExpression(ctx context.Context, expression string, td templateData) (map[string]any, error) {
+// exprData is the pre-built expression environment (from triggerExprData, optionally enriched with vars).
+func (r *WebRequestCommitStatusReconciler) evaluateTriggerDataExpression(ctx context.Context, expression string, exprData map[string]any) (map[string]any, error) {
 	logger := log.FromContext(ctx)
 
 	program, err := r.getCompiledTriggerDataExpression(expression)
@@ -162,7 +206,7 @@ func (r *WebRequestCommitStatusReconciler) evaluateTriggerDataExpression(ctx con
 		return nil, fmt.Errorf("failed to compile trigger data expression: %w", err)
 	}
 
-	output, err := expr.Run(program, td.triggerExprData())
+	output, err := expr.Run(program, exprData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate trigger data expression: %w", err)
 	}


### PR DESCRIPTION
Adds a Vars field to WhenWithOutputSpec so users can compute shared
sub-expressions once and reference them from both when.expression and
when.output.expression, removing the need to duplicate e.g. a find()
call in both fields.

- api: add Vars *OutputSpec to WhenWithOutputSpec with docs and examples
- expressions: add getCompiledVarsExpression, evaluateVarsExpression,
  and mergeVars helpers; refactor evaluateTriggerExpression and
  evaluateTriggerDataExpression to accept pre-built exprData (consistent
  with the success-expression pattern)
- controller: evaluate trigger vars in evaluateTriggerDecision before
  running trigger and output expressions; add applySuccessVars helper
  and call it in both fireOrCarryForward and handleHTTPRequestAndValidation
  so success.when and success.when.output share the same vars

https://claude.ai/code/session_0116vfC1AopjzxvYscw5gGFe