### PR TITLE
feat: configurable merge commit message template for promotion PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -215,6 +215,7 @@ You may optionally include a scope in parentheses after the type:
    - Use regex validation for character restrictions
    - Use metav1 types for time and duration fields instead of custom types
    - For numbers where negative values don't make sense, enforce a minimum of zero
+   - Prefer `// +k8s:immutable` for immutability only when the field has no other `XValidation` rules; otherwise use explicit `+kubebuilder:validation:XValidation:rule="self == oldSelf",message="field is immutable"` for all CEL rules on that field. Do **not** mix `+k8s:` markers with `XValidation` on one field — controller-gen emits nondeterministic rule order and CRD bases flap in CI ([controller-tools#1429](https://github.com/kubernetes-sigs/controller-tools/issues/1429); see `docs/contributing/writing-cel-rules.md`)
 3. Update example files in `internal/controller/testdata/` for both spec and status changes
 4. Run `make build-installer` to regenerate CRDs, DeepCopy methods, and install manifests
 5. Update controller logic

--- a/api/v1alpha1/controllerconfiguration_types.go
+++ b/api/v1alpha1/controllerconfiguration_types.go
@@ -326,6 +326,9 @@ type Bucket struct {
 // Templates use Go template syntax and have access to Sprig functions for flexible string
 // manipulation and formatting.
 //
+// The optional CommitMessage template customizes the merge commit message; commit trailers required by the
+// promoter are appended automatically after the rendered message.
+//
 // Template data available when rendering (used by the ChangeTransferPolicy controller when creating/updating PRs):
 //   - .ChangeTransferPolicy – the ChangeTransferPolicy for the managing this PullRequest
 //   - .PromotionStrategy – the PromotionStrategy for the CTP
@@ -339,6 +342,15 @@ type PullRequestTemplate struct {
 	// Uses Go template syntax with Sprig functions available for string manipulation.
 	// +required
 	Description string `json:"description"`
+
+	// CommitMessage is an optional template used to generate the merge commit message for the pull request.
+	// When set, it replaces the default commit message of "<title>\n\n<description>" (rendered from the Title
+	// and Description templates above). When unset, the default behavior is unchanged.
+	// Machine-read commit trailers used by the promoter to reconstruct promotion history are always appended
+	// after the rendered message; do not attempt to include them in the template.
+	// Uses Go template syntax with Sprig functions available for string manipulation.
+	// +optional
+	CommitMessage string `json:"commitMessage,omitempty"`
 }
 
 // ControllerConfigurationStatus defines the observed state of ControllerConfiguration.

--- a/api/v1alpha1/pullrequest_types.go
+++ b/api/v1alpha1/pullrequest_types.go
@@ -36,22 +36,28 @@ type PullRequestSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	Title string `json:"title"`
+	// Immutability is enforced via an explicit XValidation rule rather than the k8s immutable
+	// marker: controller-gen iterates markers of different names in random map order, so mixing
+	// the two makes the emitted x-kubernetes-validations rule order nondeterministic.
+
 	// TargetBranch is the head the git reference we are merging from Head ---> Base
 	// Must not start with '-', contain ':', or contain '..'.
-	// +k8s:immutable
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=100
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="field is immutable"
 	// +kubebuilder:validation:XValidation:rule="!self.startsWith('-')",message="branch must not start with '-'"
 	// +kubebuilder:validation:XValidation:rule="!self.contains(':')",message="branch must not contain ':'"
 	// +kubebuilder:validation:XValidation:rule="!self.contains('..')",message="branch must not contain '..'"
 	TargetBranch string `json:"targetBranch"`
+	// Immutability via explicit XValidation rather than the k8s immutable marker — see TargetBranch.
+
 	// SourceBranch is the base the git reference that we are merging into Head ---> Base
 	// Must not start with '-', contain ':', or contain '..'.
-	// +k8s:immutable
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=100
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="field is immutable"
 	// +kubebuilder:validation:XValidation:rule="!self.startsWith('-')",message="branch must not start with '-'"
 	// +kubebuilder:validation:XValidation:rule="!self.contains(':')",message="branch must not contain ':'"
 	// +kubebuilder:validation:XValidation:rule="!self.contains('..')",message="branch must not contain '..'"

--- a/api/view/v1alpha1/zz_generated.openapi.go
+++ b/api/view/v1alpha1/zz_generated.openapi.go
@@ -4052,7 +4052,7 @@ func schema_argoproj_labs_gitops_promoter_api_v1alpha1_PullRequestTemplate(ref c
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "PullRequestTemplate defines the template configuration for generating pull requests.\n\nTemplates use Go template syntax and have access to Sprig functions for flexible string manipulation and formatting.\n\nTemplate data available when rendering (used by the ChangeTransferPolicy controller when creating/updating PRs):\n  - .ChangeTransferPolicy – the ChangeTransferPolicy for the managing this PullRequest\n  - .PromotionStrategy – the PromotionStrategy for the CTP",
+				Description: "PullRequestTemplate defines the template configuration for generating pull requests.\n\nTemplates use Go template syntax and have access to Sprig functions for flexible string manipulation and formatting.\n\nThe optional CommitMessage template customizes the merge commit message; commit trailers required by the promoter are appended automatically after the rendered message.\n\nTemplate data available when rendering (used by the ChangeTransferPolicy controller when creating/updating PRs):\n  - .ChangeTransferPolicy – the ChangeTransferPolicy for the managing this PullRequest\n  - .PromotionStrategy – the PromotionStrategy for the CTP",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"title": {
@@ -4067,6 +4067,13 @@ func schema_argoproj_labs_gitops_promoter_api_v1alpha1_PullRequestTemplate(ref c
 						SchemaProps: spec.SchemaProps{
 							Description: "Description is the template used to generate the body/description of the pull request. Uses Go template syntax with Sprig functions available for string manipulation.",
 							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"commitMessage": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CommitMessage is an optional template used to generate the merge commit message for the pull request. When set, it replaces the default commit message of \"<title>\\n\\n<description>\" (rendered from the Title and Description templates above). When unset, the default behavior is unchanged. Machine-read commit trailers used by the promoter to reconstruct promotion history are always appended after the rendered message; do not attempt to include them in the template. Uses Go template syntax with Sprig functions available for string manipulation.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/applyconfiguration/api/v1alpha1/pullrequesttemplate.go
+++ b/applyconfiguration/api/v1alpha1/pullrequesttemplate.go
@@ -25,6 +25,9 @@ package v1alpha1
 // Templates use Go template syntax and have access to Sprig functions for flexible string
 // manipulation and formatting.
 //
+// The optional CommitMessage template customizes the merge commit message; commit trailers required by the
+// promoter are appended automatically after the rendered message.
+//
 // Template data available when rendering (used by the ChangeTransferPolicy controller when creating/updating PRs):
 // - .ChangeTransferPolicy – the ChangeTransferPolicy for the managing this PullRequest
 // - .PromotionStrategy – the PromotionStrategy for the CTP
@@ -35,6 +38,13 @@ type PullRequestTemplateApplyConfiguration struct {
 	// Description is the template used to generate the body/description of the pull request.
 	// Uses Go template syntax with Sprig functions available for string manipulation.
 	Description *string `json:"description,omitempty"`
+	// CommitMessage is an optional template used to generate the merge commit message for the pull request.
+	// When set, it replaces the default commit message of "<title>\n\n<description>" (rendered from the Title
+	// and Description templates above). When unset, the default behavior is unchanged.
+	// Machine-read commit trailers used by the promoter to reconstruct promotion history are always appended
+	// after the rendered message; do not attempt to include them in the template.
+	// Uses Go template syntax with Sprig functions available for string manipulation.
+	CommitMessage *string `json:"commitMessage,omitempty"`
 }
 
 // PullRequestTemplateApplyConfiguration constructs a declarative configuration of the PullRequestTemplate type for use with
@@ -56,5 +66,13 @@ func (b *PullRequestTemplateApplyConfiguration) WithTitle(value string) *PullReq
 // If called multiple times, the Description field is set to the value of the last call.
 func (b *PullRequestTemplateApplyConfiguration) WithDescription(value string) *PullRequestTemplateApplyConfiguration {
 	b.Description = &value
+	return b
+}
+
+// WithCommitMessage sets the CommitMessage field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the CommitMessage field is set to the value of the last call.
+func (b *PullRequestTemplateApplyConfiguration) WithCommitMessage(value string) *PullRequestTemplateApplyConfiguration {
+	b.CommitMessage = &value
 	return b
 }

--- a/config/crd/bases/promoter.argoproj.io_controllerconfigurations.yaml
+++ b/config/crd/bases/promoter.argoproj.io_controllerconfigurations.yaml
@@ -1113,6 +1113,15 @@ spec:
                       Template is the template configuration used to generate pull request titles and descriptions.
                       Uses Go template syntax with Sprig functions available.
                     properties:
+                      commitMessage:
+                        description: |-
+                          CommitMessage is an optional template used to generate the merge commit message for the pull request.
+                          When set, it replaces the default commit message of "<title>\n\n<description>" (rendered from the Title
+                          and Description templates above). When unset, the default behavior is unchanged.
+                          Machine-read commit trailers used by the promoter to reconstruct promotion history are always appended
+                          after the rendered message; do not attempt to include them in the template.
+                          Uses Go template syntax with Sprig functions available for string manipulation.
+                        type: string
                       description:
                         description: |-
                           Description is the template used to generate the body/description of the pull request.

--- a/dist/install-with-dashboard-byo-cert.yaml
+++ b/dist/install-with-dashboard-byo-cert.yaml
@@ -3217,6 +3217,15 @@ spec:
                       Template is the template configuration used to generate pull request titles and descriptions.
                       Uses Go template syntax with Sprig functions available.
                     properties:
+                      commitMessage:
+                        description: |-
+                          CommitMessage is an optional template used to generate the merge commit message for the pull request.
+                          When set, it replaces the default commit message of "<title>\n\n<description>" (rendered from the Title
+                          and Description templates above). When unset, the default behavior is unchanged.
+                          Machine-read commit trailers used by the promoter to reconstruct promotion history are always appended
+                          after the rendered message; do not attempt to include them in the template.
+                          Uses Go template syntax with Sprig functions available for string manipulation.
+                        type: string
                       description:
                         description: |-
                           Description is the template used to generate the body/description of the pull request.

--- a/dist/install-with-dashboard-cert-manager.yaml
+++ b/dist/install-with-dashboard-cert-manager.yaml
@@ -3217,6 +3217,15 @@ spec:
                       Template is the template configuration used to generate pull request titles and descriptions.
                       Uses Go template syntax with Sprig functions available.
                     properties:
+                      commitMessage:
+                        description: |-
+                          CommitMessage is an optional template used to generate the merge commit message for the pull request.
+                          When set, it replaces the default commit message of "<title>\n\n<description>" (rendered from the Title
+                          and Description templates above). When unset, the default behavior is unchanged.
+                          Machine-read commit trailers used by the promoter to reconstruct promotion history are always appended
+                          after the rendered message; do not attempt to include them in the template.
+                          Uses Go template syntax with Sprig functions available for string manipulation.
+                        type: string
                       description:
                         description: |-
                           Description is the template used to generate the body/description of the pull request.

--- a/dist/install-without-ui.yaml
+++ b/dist/install-without-ui.yaml
@@ -3217,6 +3217,15 @@ spec:
                       Template is the template configuration used to generate pull request titles and descriptions.
                       Uses Go template syntax with Sprig functions available.
                     properties:
+                      commitMessage:
+                        description: |-
+                          CommitMessage is an optional template used to generate the merge commit message for the pull request.
+                          When set, it replaces the default commit message of "<title>\n\n<description>" (rendered from the Title
+                          and Description templates above). When unset, the default behavior is unchanged.
+                          Machine-read commit trailers used by the promoter to reconstruct promotion history are always appended
+                          after the rendered message; do not attempt to include them in the template.
+                          Uses Go template syntax with Sprig functions available for string manipulation.
+                        type: string
                       description:
                         description: |-
                           Description is the template used to generate the body/description of the pull request.

--- a/docs/contributing/maintaining-crds.md
+++ b/docs/contributing/maintaining-crds.md
@@ -80,7 +80,7 @@ CI’s **Check Codegen** job runs `make build-installer` and fails on drift; see
 ## API design reminders
 
 - Put validation on Go types with kubebuilder markers (`// +kubebuilder:validation:…`, CEL `XValidation`, and so on); do not hand-edit `config/crd/bases/` except via generation.
-- Prefer **`// +k8s:immutable`** on fields that must not change after set (controller-gen v0.21+); it emits the same `self == oldSelf` rule as hand-written immutability `XValidation` (see `PullRequest` `sourceBranch` / `targetBranch`).
+- Prefer **`// +k8s:immutable`** on fields that must not change after set (controller-gen v0.21+) when that field has **no other** `XValidation` rules. It emits the same `self == oldSelf` CEL rule as a hand-written immutability `XValidation`. If the field also needs custom CEL checks, use explicit `XValidation` for immutability too — **do not mix `+k8s:` markers with `XValidation` on one field** ([controller-tools#1429](https://github.com/kubernetes-sigs/controller-tools/issues/1429); see [Writing CEL Validation Rules](writing-cel-rules.md)). Example in-tree: `PullRequest` `sourceBranch` / `targetBranch`.
 - Use **`// +k8s:enum`** on a `type Foo string` plus `const` block only when **every** field typed `Foo` shares the same allowed values. Remove redundant field `Enum` markers only in that case. Do **not** put `+k8s:enum` on a type that is also used from status fields allowing `""` or a subset of consts (controller-gen applies the type enum to all references; field `Enum` is not merged for extras like `""`). Example in-tree: `ContextMode` on `WebRequestCommitStatus`. Plain `string` fields still use field `Enum`.
 - Express reconciler RBAC with **`// +kubebuilder:rbac`** on controllers; regenerate manifests rather than editing `config/rbac/role.yaml` by hand.
 - For SCM-facing types and commit-status controllers, see [Adding an SCM Provider](adding-an-scm-provider.md) and [Developing a CommitStatus](developing-a-commitstatus.md).
@@ -90,6 +90,7 @@ CI’s **Check Codegen** job runs `make build-installer` and fails on drift; see
 | Topic | Page |
 |--------|------|
 | User-facing CR reference | [CRD Specs](../crd-specs.md) |
+| CEL rules and marker mixing | [Writing CEL Validation Rules](writing-cel-rules.md) |
 | Status subresource / SSA | [Maintaining resource status](updating-status.md) |
 | CI codegen checks | [Continuous Integration](ci.md) |
 | Contributor overview | [Contributing overview](index.md) |

--- a/docs/contributing/writing-cel-rules.md
+++ b/docs/contributing/writing-cel-rules.md
@@ -12,6 +12,37 @@ and `make build-installer` compiles them into the CRD bases under `config/crd/`.
 RepoURL string `json:"repoURL,omitempty"`
 ```
 
+## Don't mix `+k8s:` markers with `XValidation` on one field
+
+controller-gen v0.21+ also understands [`+k8s:` declarative validation
+markers](https://www.kubernetes.dev/docs/code/declarative-validation/) (for example
+`+k8s:immutable`, `+k8s:minLength`). Like hand-written `XValidation` markers, these compile into
+`x-kubernetes-validations` CEL rules on the field.
+
+**Do not put both marker families on the same field.** When a field mixes `+k8s:` markers with
+`+kubebuilder:validation:XValidation`, controller-gen emits the rules from each family in
+declared order internally, but the *relative* order of the two families is
+[nondeterministic across
+runs](https://github.com/kubernetes-sigs/controller-tools/issues/1429). Committed CRD bases under
+`config/crd/bases/` then flap between equivalent orderings, which breaks CI checks that diff
+generated manifests.
+
+**Workaround:** keep all CEL rules on a field under one marker family. When a field needs both
+immutability and custom CEL checks, replace `+k8s:immutable` with an explicit immutability rule so
+every rule is an `XValidation` marker:
+
+```go
+// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="field is immutable"
+// +kubebuilder:validation:XValidation:rule="!self.startsWith('-')",message="branch must not start with '-'"
+Branch string `json:"branch"`
+```
+
+In-tree example: `PullRequest` `sourceBranch` / `targetBranch` in
+[`api/v1alpha1/pullrequest_types.go`](https://github.com/argoproj-labs/gitops-promoter/blob/main/api/v1alpha1/pullrequest_types.go).
+
+`+k8s:immutable` (and other `+k8s:` markers that emit CEL) is still fine on fields that have **no**
+other `XValidation` rules on the same field.
+
 ## The apiserver cost budget
 
 When a CRD is created or updated, the kube-apiserver estimates a **static worst-case cost** for

--- a/docs/crd-specs.md
+++ b/docs/crd-specs.md
@@ -122,6 +122,11 @@ A global ControllerConfiguration is deployed alongside the controller and applie
 
 All fields are required, but defaults are provided in the installation manifests.
 
+The `pullRequest.template` section controls the title and description of promotion PRs. The optional
+`commitMessage` field customizes the merge commit message; when unset, the message defaults to the rendered
+title and description. Commit trailers used by the promoter to reconstruct promotion history are always
+appended automatically after the rendered message.
+
 ```yaml
 {!internal/controller/testdata/ControllerConfiguration.yaml!}
 ```

--- a/internal/controller/changetransferpolicy_controller.go
+++ b/internal/controller/changetransferpolicy_controller.go
@@ -1091,6 +1091,17 @@ func (r *ChangeTransferPolicyReconciler) createOrUpdatePullRequest(ctx context.C
 		return nil, fmt.Errorf("failed to template pull request: %w", err)
 	}
 
+	baseCommitMessage, err := TemplateCommitMessage(templatePullRequestTemplate, templateData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to template pull request commit message: %w", err)
+	}
+	if baseCommitMessage == "" {
+		baseCommitMessage = fmt.Sprintf("%s\n\n%s", title, description)
+	}
+	// The trailer block must remain the final paragraph of the commit message, so trailing newlines from the
+	// rendered template must not detach it.
+	baseCommitMessage = strings.TrimRight(baseCommitMessage, "\n")
+
 	// Check if the PR already exists to determine the commit message
 	existingPR := &promoterv1alpha1.PullRequest{}
 	prExists := true
@@ -1109,7 +1120,7 @@ func (r *ChangeTransferPolicyReconciler) createOrUpdatePullRequest(ctx context.C
 	var commitMessage string
 	if !prExists {
 		// New PR
-		commitMessage = fmt.Sprintf("%s\n\n%s", title, description)
+		commitMessage = baseCommitMessage
 	} else {
 		// Update existing PR - add trailers
 		commitTrailers := trailers{}
@@ -1132,7 +1143,7 @@ func (r *ChangeTransferPolicyReconciler) createOrUpdatePullRequest(ctx context.C
 		commitTrailers[constants.TrailerShaDryActive] = ctp.Status.Active.Dry.Sha
 		commitTrailers[constants.TrailerShaDryProposed] = ctp.Status.Proposed.Dry.Sha
 
-		commitMessage = fmt.Sprintf("%s\n\n%s\n\n%s", title, description, commitTrailers)
+		commitMessage = fmt.Sprintf("%s\n\n%s", baseCommitMessage, commitTrailers)
 	}
 
 	// Determine the state: preserve existing state if PR exists, otherwise default to open
@@ -1377,6 +1388,19 @@ func TemplatePullRequest(prt promoterv1alpha1.PullRequestTemplate, data map[stri
 	}
 
 	return title, description, nil
+}
+
+// TemplateCommitMessage renders the optional commit message template of a pull request template using the
+// provided data map. Returns an empty string if no commit message template is configured.
+func TemplateCommitMessage(prt promoterv1alpha1.PullRequestTemplate, data map[string]any) (string, error) {
+	if prt.CommitMessage == "" {
+		return "", nil
+	}
+	commitMessage, err := utils.RenderStringTemplate(prt.CommitMessage, data)
+	if err != nil {
+		return "", fmt.Errorf("failed to render pull request commit message template: %w", err)
+	}
+	return commitMessage, nil
 }
 
 // boolPtrEqual compares two *bool pointers for equality.

--- a/internal/controller/changetransferpolicy_controller_test.go
+++ b/internal/controller/changetransferpolicy_controller_test.go
@@ -1103,6 +1103,79 @@ var _ = Describe("TemplatePullRequest", func() {
 	})
 })
 
+var _ = Describe("TemplateCommitMessage", func() {
+	Context("Commit message template with ChangeTransferPolicy and optional PromotionStrategy", func() {
+		ctp := &promoterv1alpha1.ChangeTransferPolicy{
+			Spec: promoterv1alpha1.ChangeTransferPolicySpec{
+				ActiveBranch:   testBranchDevelopment,
+				ProposedBranch: testBranchDevelopmentNext,
+			},
+			Status: promoterv1alpha1.ChangeTransferPolicyStatus{
+				Proposed: promoterv1alpha1.CommitBranchState{
+					Dry: promoterv1alpha1.CommitShaState{
+						Sha:     "abc1234def",
+						Subject: "feat: add new feature",
+					},
+				},
+			},
+		}
+
+		It("returns an empty string when no commit message template is configured", func() {
+			template := promoterv1alpha1.PullRequestTemplate{
+				Title:       "some title",
+				Description: "some description",
+			}
+			commitMessage, err := TemplateCommitMessage(template, map[string]any{"ChangeTransferPolicy": ctp})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(commitMessage).To(BeEmpty())
+		})
+
+		It("renders the commit message with only CTP when PromotionStrategy is absent", func() {
+			template := promoterv1alpha1.PullRequestTemplate{
+				Title:         "some title",
+				Description:   "some description",
+				CommitMessage: "{{ .ChangeTransferPolicy.Status.Proposed.Dry.Subject }} (dry: {{ trunc 7 .ChangeTransferPolicy.Status.Proposed.Dry.Sha }}){{ if .PromotionStrategy }} Strategy: {{ .PromotionStrategy.Name }}{{ end }}",
+			}
+			commitMessage, err := TemplateCommitMessage(template, map[string]any{"ChangeTransferPolicy": ctp})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(commitMessage).To(Equal("feat: add new feature (dry: abc1234)"))
+		})
+
+		It("renders the commit message with CTP and PromotionStrategy when PromotionStrategy is present", func() {
+			psName := "my-promotion-strategy"
+			ps := &promoterv1alpha1.PromotionStrategy{
+				ObjectMeta: metav1.ObjectMeta{Name: psName, Namespace: "default"},
+				Spec: promoterv1alpha1.PromotionStrategySpec{
+					RepositoryReference: promoterv1alpha1.ObjectReference{Name: "test-repo"},
+					Environments:        []promoterv1alpha1.Environment{{Branch: testBranchDevelopment}},
+				},
+			}
+			template := promoterv1alpha1.PullRequestTemplate{
+				Title:         "some title",
+				Description:   "some description",
+				CommitMessage: "{{ .ChangeTransferPolicy.Status.Proposed.Dry.Subject }}{{ if .PromotionStrategy }} Strategy: {{ .PromotionStrategy.Name }}{{ end }}",
+			}
+			commitMessage, err := TemplateCommitMessage(template, map[string]any{
+				"ChangeTransferPolicy": ctp,
+				"PromotionStrategy":    ps,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(commitMessage).To(Equal("feat: add new feature Strategy: " + psName))
+		})
+
+		It("returns an error when the commit message template is invalid", func() {
+			template := promoterv1alpha1.PullRequestTemplate{
+				Title:         "some title",
+				Description:   "some description",
+				CommitMessage: "{{ .Invalid",
+			}
+			_, err := TemplateCommitMessage(template, map[string]any{"ChangeTransferPolicy": ctp})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to render pull request commit message template"))
+		})
+	})
+})
+
 var _ = Describe("tooManyPRsError", func() {
 	Context("When formatting tooManyPRsError", func() {
 		It("returns an error listing all PR names if 3 or fewer", func() {

--- a/internal/controller/testdata/ControllerConfiguration.yaml
+++ b/internal/controller/testdata/ControllerConfiguration.yaml
@@ -50,6 +50,10 @@ spec:
         **Changes:**
         - Current SHA: {{ .ChangeTransferPolicy.Status.Active.Dry.Sha }}
         - Proposed SHA: {{ .ChangeTransferPolicy.Status.Proposed.Dry.Sha }}
+      # Optional: customize the merge commit message of the promotion PR.
+      # When unset, the message defaults to "<title>\n\n<description>" rendered from the templates above.
+      # Machine-read promotion trailers are always appended automatically after the rendered message.
+      commitMessage: "promote: {{ .ChangeTransferPolicy.Status.Proposed.Dry.Subject }} ({{ trunc 7 .ChangeTransferPolicy.Status.Proposed.Dry.Sha }})"
     workQueue:
       requeueDuration: "5m"
       maxConcurrentReconciles: 3


### PR DESCRIPTION
Add an optional commitMessage field to ControllerConfiguration's
spec.pullRequest.template. When set, the rendered template replaces the
default merge commit message of "<title>\n\n<description>"; when unset,
behavior is unchanged. The template uses Go template syntax with Sprig
functions and receives the same data as the title/description templates
(.ChangeTransferPolicy and .PromotionStrategy), giving access to the dry
commit's subject, body, author, date, and SHA via
.ChangeTransferPolicy.Status.Proposed.Dry.

Machine-read commit trailers used to reconstruct promotion history are
always appended after the rendered message, and trailing newlines are
trimmed from the rendered template so the trailer block remains the
final paragraph.

Closes argoproj-labs/gitops-promoter#1562

https://claude.ai/code/session_01JXTyyEttfvJAktebvzwepv