### PR TITLE
chore: add Claude Code skills for repo-specific workflows

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: architecture
+description: Understand GitOps Promoter's architecture — the promotion model, CRDs and their relationships, controller layout, and where code lives. Use when orienting in the codebase, designing a feature, or answering "where does X happen / where should Y go" questions.
+---
+
+# GitOps Promoter Architecture
+
+## What it does
+
+GitOps Promoter is a Kubernetes operator (controller-runtime / kubebuilder) that promotes GitOps config through environments. Users commit once to a "DRY branch"; a hydrator renders environment-specific "hydrated branches" (`environment/<env>` + `environment/<env>-next`), and the promoter moves changes between them via pull requests, gated by commit statuses. Diagrams: `docs/architecture.md`.
+
+## CRDs (`api/v1alpha1/`) and relationships
+
+| Kind | Role |
+| --- | --- |
+| `PromotionStrategy` | Top-level: ordered environments + which commit statuses gate promotion. Creates one `ChangeTransferPolicy` per environment. |
+| `ChangeTransferPolicy` (CTP) | Moves changes from proposed to active branch for one environment; creates `PullRequest` objects. |
+| `PullRequest` | Represents a promotion PR in the SCM (open/merge/close via provider). |
+| `CommitStatus` | A gate result for a SHA; matched to strategy gates by the `promoter.argoproj.io/commit-status` label. |
+| `GitRepository` | A git repo; references an `ScmProvider` or `ClusterScmProvider`. |
+| `ScmProvider` / `ClusterScmProvider` | SCM config (GitHub, GitLab, Gitea, Forgejo, Bitbucket Cloud, Azure DevOps); references a Secret for creds. |
+| Gate CRs: `ArgoCDCommitStatus`, `TimedCommitStatus`, `GitCommitStatus`, `WebRequestCommitStatus` | Built-in gate controllers that create `CommitStatus` objects; all carry `spec.promotionStrategyRef`. |
+| `RevertCommit` | Represents a revert operation. |
+| `ControllerConfiguration` | Operator-wide config; defaults live in `config/config/controllerconfiguration.yaml` manifests, not code. |
+
+Chain: `PromotionStrategy` → `ChangeTransferPolicy` (per env) → `PullRequest`; gates → `CommitStatus`; `PromotionStrategy`/gates reference `GitRepository` → `ScmProvider`/`ClusterScmProvider` → `Secret`.
+
+## Package map
+
+- `api/v1alpha1/` — CRD types, validation markers, label/finalizer constants (`constants.go`). `zz_generated.*` files are generated.
+- `internal/controller/` — one reconciler per kind; shared helpers in `event_utils.go`, `fieldindex.go`, `finalizer_utils.go`; example CRs in `testdata/`.
+- `internal/scms/` — provider interfaces (`commitstatus.go`, `pullrequest.go`) and per-provider packages (`github/`, `gitlab/`, `gitea/`, `forgejo/`, `bitbucket_cloud/`, `azuredevops/`, `fake/`, `mock/`).
+- `internal/git/` — git plumbing (bare repos; auth via `internal/gitauth`).
+- `internal/webhookreceiver/` — inbound SCM webhooks that trigger fast reconciles.
+- `internal/metrics/` — Prometheus metrics incl. `RecordSCMCall`.
+- `internal/apiserver/` + `api/view/` — dashboard extension apiserver (aggregation API, **not** CRDs — deliberately excluded from CRD codegen).
+- `internal/webserver/`, `ui/dashboard/`, `ui/extension/`, `ui/components-lib/` — dashboard web server, React dashboard, Argo CD extension.
+- `internal/settings/`, `internal/utils/`, `internal/types/argocd/` — config accessors, shared helpers (e.g. `KubeSafeLabel`), vendored Argo CD Application type.
+- `config/` — kustomize manifests; `config/crd/bases/` is generated, never hand-edit.
+- `hack/`, `test/e2e/`, `docs/` (MkDocs), `webrequestsimulator/`.
+
+## Key architectural rules
+
+- **Status writes go through one chokepoint**: the deferred `utils.HandleReconciliationResult` at the top of each `Reconcile` applies status via Server-Side Apply with a per-controller field owner. Controllers mutate `obj.Status` in memory only — never call `r.Status().Update()`/`Patch()` directly. Details: `docs/contributing/updating-status.md` and the `controller-patterns` skill.
+- **Gate controllers list by field index**, not namespace-list + filter: `client.MatchingFields{controller.PromotionStrategyRefField: ps.Name}` with indexes registered in `internal/controller/fieldindex.go`.
+- **Every SCM API call records metrics** via `metrics.RecordSCMCall`.
+- **RBAC is declared as `// +kubebuilder:rbac` markers** on controllers; `config/rbac/role.yaml` is generated.
+- Labels/finalizers use constants from `api/v1alpha1/constants.go`; free-form label values are sanitized with `utils.KubeSafeLabel()`.
+
+## Where to go deeper
+
+`docs/contributing/` covers: adding an SCM provider, developing a commit-status gate, maintaining CRDs, writing CEL rules, status handling, finalizers, CI, and the Argo CD extension. Prefer following an existing controller/provider as a template over inventing new patterns.

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: code-review
+description: Review GitOps Promoter pull requests and diffs against this repo's specific conventions — status/SSA rules, CRD validation markers, codegen drift, SCM metrics, finalizers, and test coverage. Use when reviewing a PR, a branch diff, or pre-commit changes.
+---
+
+# Reviewing GitOps Promoter changes
+
+Review in this order: correctness bugs first, then repo-convention violations, then style. Cite `file:line` for every finding.
+
+## Repo-specific checklist
+
+### API / CRD changes (`api/v1alpha1/`)
+
+- Generated files in sync? A diff touching Go types **must** include regenerated `zz_generated.*`, `config/crd/bases/`, `applyconfiguration/`, and `dist/` (CI "Check Codegen" runs `make build-installer`).
+- Validation markers present: required strings get `MinLength=1`; max lengths where sensible; regex for restricted charsets; non-negative numbers get `Minimum=0`; time/duration fields use `metav1` types.
+- Immutability: `// +k8s:immutable` **only** when the field has no other `XValidation`; otherwise explicit `XValidation:rule="self == oldSelf"`. Never mix `+k8s:` markers with `XValidation` on one field (controller-tools#1429 — nondeterministic rule order flaps CI).
+- `internal/controller/testdata/<Kind>.yaml` updated for both spec and status changes (strict-unmarshal tests fail otherwise); `docs/crd-specs.md` section updated; `+kubebuilder:externalDocs` on new root types.
+- New `ControllerConfiguration` fields: default set explicitly in `config/config/controllerconfiguration.yaml` (defaults live in manifests, not code).
+
+### Controller changes (`internal/controller/`)
+
+- No direct `r.Status().Update()` / `r.Status().Patch()` — status flows only through the deferred `utils.HandleReconciliationResult`.
+- Ready condition cleared right after fetch (`meta.RemoveStatusCondition(..., Ready)`).
+- NotFound handled gracefully; requeues via `ctrl.Result{RequeueAfter: ...}`; structured `logr` logging.
+- Finalizer names come from `api/v1alpha1/constants.go` and follow the naming patterns; cross-resource finalizer updates use SSA, not `Update` (Secrets are the documented exception). Watches on dependencies whose finalizers matter during deletion must not be generation-only-filtered.
+- Gate lookups use field indexes (`client.MatchingFields` + `fieldindex.go`), not list-and-filter.
+- RBAC changes are `// +kubebuilder:rbac` markers + regenerated role.yaml, not hand edits.
+
+### SCM changes (`internal/scms/`)
+
+- Every provider HTTP API call records `metrics.RecordSCMCall` exactly once per logical request, with a real or sensible fallback status code (`500` when no response), after the call completes.
+- Errors wrapped with `%w`; follows the structure of an existing provider (e.g. `internal/scms/github/`).
+
+### Tests
+
+- Behavior changes come with envtest specs; async assertions use `Eventually`, not bare `Expect`.
+- Both success and error paths covered; cleanup in `AfterEach`.
+- Fake clients that use `MatchingFields` register the matching field indexes.
+
+### Docs & hygiene
+
+- Behavior/API changes update `docs/` (and `mkdocs.yml` for new pages); `make lint-docs` clean.
+- PR title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `test:`, `refactor:`, `perf:`, `ci:`, `build:`, `style:`, optional scope).
+- No new dependencies without justification; no edits to generated files; minimal diff for the stated goal.
+
+## Verification commands for a review
+
+```bash
+make build-installer && git status --porcelain   # codegen drift check
+make lint
+make test-parallel
+```

--- a/.claude/skills/controller-patterns/SKILL.md
+++ b/.claude/skills/controller-patterns/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: controller-patterns
+description: Write or modify GitOps Promoter reconcilers correctly — status via SSA chokepoint, Ready conditions, observedGeneration, finalizer conventions, watches, and field indexes. Use when writing, editing, or wiring up controller code in internal/controller/.
+---
+
+# Controller patterns
+
+Authoritative docs: `docs/contributing/updating-status.md` and `docs/contributing/using-finalizers.md`. Follow an existing reconciler (e.g. `promotionstrategy_controller.go`) as a template.
+
+## Status: one chokepoint, SSA only
+
+1. Start every `Reconcile` with the deferred helper:
+   ```go
+   defer utils.HandleReconciliationResult(ctx, startTime, &obj,
+       r.Client, r.Recorder,
+       constants.<Kind>ControllerFieldOwner,
+       &result, &err)
+   ```
+2. Immediately after fetching the object, **clear the stale Ready condition**:
+   ```go
+   meta.RemoveStatusCondition(obj.GetConditions(), string(promoterConditions.Ready))
+   ```
+   The deferred helper can't tell "set this reconcile" from "left over from last time" — skipping this bleeds stale state forward.
+3. Mutate `obj.Status` in memory during reconciliation. **Never call `r.Status().Update()` or `r.Status().Patch()` yourself.**
+4. The helper sets Ready from `*err`, stamps `status.observedGeneration = metadata.generation`, and applies the whole status via SSA with `ForceOwnership` under the controller's field owner. If validation rejects the full apply, it retries conditions-only under a `<owner>-fallback` field owner without advancing `observedGeneration` (that's the "stored status is stale" signal).
+
+`observedGeneration` semantics: `== generation` means status is current; `< generation` means not caught up or last apply rejected; oscillating values mean two replicas are racing (check leader election).
+
+## Finalizers
+
+- Define strings as constants in `api/v1alpha1/constants.go`. Patterns:
+  - Own lifecycle: `<kind>.promoter.argoproj.io/finalizer`
+  - Placed by another controller: `<controller-kind>.promoter.argoproj.io/<finalized-kind>-finalizer`
+- Names are API — never change a shipped finalizer string (strands objects).
+- The controller that owns the cleanup adds *and* removes its finalizer. Standard flow: add on reconcile when not deleting (`controllerutil.AddFinalizer` + `Update`); on `deletionTimestamp`, run cleanup then remove.
+- **Cross-resource** finalizer add/remove uses SSA (`ApplyPatchType`, typed apply config, stable `client.FieldOwner`), no `RetryOnConflict` needed. Exception: Secret finalizers for ScmProvider still use `controllerutil` + `Update` + `RetryOnConflict`.
+- Deletion-ordering trap: if controller A waits on B's finalizers but watches B with generation-only predicates, A gets stuck `Terminating`. Add a predicate whose Update path returns true when `B.DeletionTimestamp != nil` and `len(B.Finalizers)` changed.
+
+## Watches, indexes, and lookups
+
+- Gate controllers watch `PromotionStrategy` and list their kind via `client.MatchingFields{controller.PromotionStrategyRefField: ps.Name}` — never namespace-list and filter in memory. Indexes are registered in `internal/controller/fieldindex.go` and must be registered on every cache that uses them (manager, dashboard read cache in `internal/apiserver/run.go`, fake clients in tests).
+- Requeue with `ctrl.Result{RequeueAfter: duration}`; handle NotFound gracefully (`client.IgnoreNotFound` pattern).
+- Emit events via the shared helpers in `event_utils.go`; use structured `logr` logging.
+
+## Labels
+
+Set correlation labels using constants from `api/v1alpha1/constants.go`; gate controllers stamp the three standard CommitStatus labels via `utils.CommitStatusStandardLabels(parent, branch, key)`. Always sanitize free-form values (branch names) with `utils.KubeSafeLabel()`. Reference table: `docs/debugging/labels.md`.
+
+## RBAC
+
+Declare permissions as `// +kubebuilder:rbac:...` markers on the reconciler, then `make manifests` — never edit `config/rbac/role.yaml` directly.

--- a/.claude/skills/crd-changes/SKILL.md
+++ b/.claude/skills/crd-changes/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: crd-changes
+description: Add or modify a CRD field or API type in GitOps Promoter — kubebuilder validation markers, CEL rules, codegen, testdata, docs, and field indexes. Use whenever touching api/v1alpha1/ types or CRD schemas.
+---
+
+# Changing CRDs / API types
+
+Full checklist lives in `docs/contributing/maintaining-crds.md`; CEL specifics in `docs/contributing/writing-cel-rules.md`. This is the condensed workflow.
+
+## Workflow for a new/changed field
+
+1. **Edit the Go type** in `api/v1alpha1/<kind>_types.go` with validation markers:
+   - Required strings: `+kubebuilder:validation:MinLength=1` (and a MaxLength when sensible).
+   - Regex validation for restricted character sets.
+   - Numbers that can't be negative: `+kubebuilder:validation:Minimum=0`.
+   - Time/duration: use `metav1.Time` / `metav1.Duration`, not custom types.
+   - Doc comments become CRD field descriptions — write them for users.
+2. **Immutability / CEL** — the one sharp edge:
+   - Use `// +k8s:immutable` **only** if the field has no other `XValidation` rules.
+   - If the field has any custom CEL, write immutability as explicit `XValidation:rule="self == oldSelf",message="field is immutable"` too.
+   - **Never mix `+k8s:` markers with `XValidation` on the same field** — controller-gen emits nondeterministic rule order and CRD bases flap in CI (controller-tools#1429). In-tree example: `PullRequest` `sourceBranch`/`targetBranch`.
+   - `// +k8s:enum` on a named string type only if *every* field using that type shares the same allowed values (status fields allowing `""` break this). Otherwise use field-level `Enum` markers.
+   - Check CEL cost with `make cel-cost-report` if adding expensive rules.
+3. **Regenerate**: `make build-installer` (CRD bases, deepcopy, applyconfiguration, dist bundles). `go mod tidy` if deps changed. Never hand-edit `config/crd/bases/`.
+4. **Update testdata**: `internal/controller/testdata/<Kind>.yaml` (PascalCase filename) — realistic spec *and* status values; the strict-unmarshal test (`DisallowUnknownFields`) fails CI on drift.
+5. **Update controller logic and tests** (envtest specs for new behavior).
+6. **Docs**: update the `### <Kind>` section in `docs/crd-specs.md` (the testdata YAML is embedded via `markdown_include`); run `make lint-docs`.
+
+## Extra steps for a brand-new kind
+
+- Root type gets `//+kubebuilder:object:root=true` plus `+kubebuilder:externalDocs:url="https://gitops-promoter.readthedocs.io/en/stable/crd-specs/#<kind-anchor>",description="CRD reference (examples and behavior)"` — anchor must match the docs heading.
+- Add the strict unmarshal test (`//go:embed testdata/<Kind>.yaml` in the controller test).
+- If it's a commit-status gate with `spec.promotionStrategyRef`: extend `PromotionStrategyRefIndexValues` and `RegisterGatePromotionStrategyRefFieldIndexes` in `internal/controller/fieldindex.go`; list with `client.MatchingFields{controller.PromotionStrategyRefField: ps.Name}`; register the index on every cache that lists it (manager setup, dashboard read cache in `internal/apiserver/run.go`) and on fake clients in tests.
+- Reconciler RBAC via `// +kubebuilder:rbac` markers, then `make manifests`.
+- The view aggregation API (`api/view/...`) is served by an extension apiserver, **not** CRDs — it is deliberately excluded from CRD codegen paths in the Makefile.
+
+## ControllerConfiguration fields
+
+Defaults live in **manifests**, not code: add the field, set the default explicitly in `config/config/controllerconfiguration.yaml`, then follow the normal validation/testing steps.
+
+## Verify
+
+```bash
+make build-installer && git status --porcelain  # must be clean (CI Check Codegen)
+make test-parallel
+make lint-docs   # if docs changed
+```
+
+While in v1alpha1 breaking changes are allowed but should be avoided when possible.

--- a/.claude/skills/debugging/SKILL.md
+++ b/.claude/skills/debugging/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: debugging
+description: Debug failing or flaky tests, controller reconcile issues, stuck deletes, and promotion problems in GitOps Promoter. Use when investigating test failures, controller misbehavior, missing CommitStatuses, stuck finalizers, or unexplained promotion behavior.
+---
+
+# Debugging GitOps Promoter
+
+## Critical rule: controller logs go to stderr
+
+Always capture stderr when running tests, or you will miss all controller-runtime logs:
+
+```bash
+# ✅ CORRECT
+go test -v ./internal/controller -ginkgo.focus="test name" -ginkgo.v -timeout 5m > /tmp/test.log 2>&1
+
+# ❌ WRONG — loses controller logs
+go test -v ./internal/controller -ginkgo.focus="test name" > /tmp/test.log
+```
+
+Validate the capture before drawing conclusions: `wc -l /tmp/test.log` — expect 500+ lines with `-ginkgo.v`. If under ~50 lines, the flags are wrong or logs weren't generated. Remember `grep` exit code 1 just means "no match", not an error.
+
+## Investigation workflow
+
+1. **Capture**: run the focused test with `-ginkgo.v 2>&1` to a file in /tmp (never in the repo).
+2. **Find failure point**: `grep -A20 "FAILED" /tmp/test.log` and `grep -B20 "FAILED"` for what led up to it.
+3. **Verify code paths executed**: grep for the log lines your code emits (e.g. `grep -c "Reconciling ChangeTransferPolicy" /tmp/test.log`). Zero matches on a *passing* test can mean a false positive — the code path never ran.
+4. **Flakiness**: `for i in {1..5}; do go test ./internal/controller -ginkgo.focus="test" -timeout 5m || break; done`, or use `make test-parallel-repeat3`. Look for timing indicators: `grep -E "timeout|reconcile.*duration"`.
+
+## Common failure causes
+
+- **"unable to find kubebuilder assets"** → run `make setup-envtest` (or just `make test`, which sets `KUBEBUILDER_ASSETS`).
+- **CRDs out of sync with Go types** → `make manifests`; missing deepcopy → `make generate`; CI "Check Codegen" drift → `make build-installer`.
+- **Async assertions failing** → controller tests must use Gomega `Eventually` for anything a reconciler does; a bare `Expect` races the reconcile loop.
+- **Status oscillating between values** → symptom of two controller replicas racing; check leader election.
+- **`status.observedGeneration` < `metadata.generation`** → reconcile hasn't caught up, or the last full status SSA was rejected (the Ready condition then carries the error and its own `observedGeneration` shows the attempted generation). See `docs/contributing/updating-status.md`.
+
+## Stuck deletes (finalizers)
+
+Objects stuck `Terminating` almost always have a leftover finalizer. Finalizer name constants live in `api/v1alpha1/constants.go` (patterns: `<kind>.promoter.argoproj.io/finalizer` for self, `<controller-kind>.promoter.argoproj.io/<finalized-kind>-finalizer` for cross-resource). A classic bug: controller A watches B with generation-only predicates, so it never sees B's finalizer-count change during deletion and A stays stuck in `Terminating`. See `docs/debugging/finalizers.md` and `docs/contributing/using-finalizers.md`.
+
+## Label-based correlation
+
+Controllers correlate resources via labels (keys in `api/v1alpha1/constants.go`):
+
+- `promoter.argoproj.io/promotion-strategy`, `promoter.argoproj.io/environment`, `promoter.argoproj.io/change-transfer-policy` link CTPs and PullRequests to their strategy/environment.
+- Gate controllers stamp three standard labels on each CommitStatus via `utils.CommitStatusStandardLabels`, including `promoter.argoproj.io/commit-status` (must match the `key` in the PromotionStrategy's active/proposed commit statuses).
+
+**Gotcha**: label values pass through `utils.KubeSafeLabel()` — slashes become hyphens and length is capped at 63 chars (`environment/development` → `environment-development`). Compare against the sanitized value, not the raw branch name. Full reference: `docs/debugging/labels.md`.
+
+## SCM call visibility
+
+Every SCM HTTP API call should be recorded via `metrics.RecordSCMCall` (`internal/metrics/metrics.go`), which also emits a structured "SCM API call" debug log line. Use `scm_calls_total` / `scm_calls_duration_seconds` metrics and those log lines to confirm whether the operator actually hit the provider API. See `docs/monitoring/logs.md` and `docs/monitoring/metrics.md`.

--- a/.claude/skills/docs-authoring/SKILL.md
+++ b/.claude/skills/docs-authoring/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: docs-authoring
+description: Write and validate GitOps Promoter documentation — MkDocs structure, markdown_include embeds, crd-specs conventions, and lint-docs. Use when adding or editing anything under docs/ or mkdocs.yml.
+---
+
+# Documentation authoring
+
+Docs are MkDocs (Material) sourced from `docs/`, published at https://gitops-promoter.readthedocs.io/.
+
+## Rules
+
+- **New page → add it to `mkdocs.yml`** nav, or it won't appear in the table of contents.
+- **Validate with `make lint-docs`** — builds the docs and fails on any MkDocs warning (broken links, missing nav entries). CI runs this on every PR. Local setup if needed:
+  ```bash
+  python3 -m venv .venv && source .venv/bin/activate
+  pip install -r docs/requirements.txt
+  mkdocs serve   # live preview
+  ```
+- **Embeds**: `markdown_include` pulls files in at build time. `docs/crd-specs.md` embeds the example CRs from `internal/controller/testdata/` with `{!internal/controller/testdata/<Kind>.yaml!}` — edit the testdata YAML (which is also strict-unmarshal-tested), not a copy in the docs. `docs/contributing/writing-cel-rules.md` embeds `hack/celcost/report.md` (regenerate with `make cel-cost-report`).
+- **Anchors are API**: `+kubebuilder:externalDocs` markers on API types point at `crd-specs` heading anchors (Material slugifies `### PromotionStrategy` → `#promotionstrategy`). Renaming a heading breaks the CRD's externalDocs URL.
+- GitHub-style alerts (`> [!NOTE]`) are supported via plugins.
+- Version references in manifests/docs are kept in sync by `hack/bump-docs-manifests.sh` (driven by the release workflow) — don't hand-bump versions across docs.
+
+## Where content goes
+
+| Content | Location |
+| --- | --- |
+| User-facing CR reference | `docs/crd-specs.md` (one `### <Kind>` section per CRD) |
+| Setup / install changes | `docs/getting-started.md` |
+| Architecture changes | `docs/architecture.md` |
+| Promotion gate docs | `docs/gating-promotions/` |
+| Contributor how-tos | `docs/contributing/` |
+| Operator debugging guides | `docs/debugging/` |
+| Metrics / logs / events | `docs/monitoring/` |
+
+Behavior or API changes should land with their docs update in the same PR. PR title prefix `docs:` for docs-only changes.

--- a/.claude/skills/refactoring/SKILL.md
+++ b/.claude/skills/refactoring/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: refactoring
+description: Safely refactor GitOps Promoter code — what is generated vs hand-written, which invariants must survive a refactor, and the verification loop to run afterward. Use when restructuring code, renaming, extracting helpers, or cleaning up without changing behavior.
+---
+
+# Refactoring GitOps Promoter
+
+## Never hand-edit generated code
+
+Regenerate instead of editing:
+
+| Files | Regenerate with |
+| --- | --- |
+| `api/v1alpha1/zz_generated.*.go`, `applyconfiguration/` | `make generate` |
+| `config/crd/bases/*.yaml`, `config/rbac/role.yaml`, `dist/` | `make manifests` / `make build-installer` |
+| Mocks (`internal/scms/mock/`, mockery output) | `make mockery-gen` |
+| `test/external_crds/argoproj.io_applications.yaml` | moved there by `make manifests` |
+
+`make build-installer` runs the full codegen chain; CI's "Check Codegen" job fails on any drift, so run it whenever you touch API types, kubebuilder markers, or RBAC markers.
+
+## Invariants that must survive a refactor
+
+- **Public strings are API**: finalizer names, label keys (`api/v1alpha1/constants.go`), CommitStatus `key` values, and field-owner names must not change — renaming a finalizer strands objects that still carry the old string; changing a field owner breaks SSA ownership of existing status.
+- **Status flow**: keep the deferred `utils.HandleReconciliationResult` at the top of `Reconcile`, keep the early `meta.RemoveStatusCondition(..., Ready)` after fetching the object, and never introduce direct `r.Status().Update/Patch` calls.
+- **Field-index lookups**: code that lists gates by strategy must keep using `client.MatchingFields` with the indexes in `internal/controller/fieldindex.go`; don't "simplify" to a namespace list + in-memory filter.
+- **SCM metrics**: any moved/extracted SCM API call must keep its `metrics.RecordSCMCall` exactly once per logical request.
+- **RBAC markers** (`// +kubebuilder:rbac`) live on the controller that needs them — moving code between controllers may require moving markers, then `make manifests`.
+- Kubebuilder validation markers and CEL `XValidation` comments are load-bearing — don't reflow or drop doc comments on API types casually (they become CRD descriptions).
+
+## Conventions to preserve
+
+- Error handling: wrap with `fmt.Errorf("...: %w", err)`; never ignore errors; no naked returns.
+- Structured logging with `logr`; keep existing log messages stable where tests or docs grep for them.
+- Follow existing controllers/providers as templates rather than introducing a new style; match the surrounding code's comment density and idiom.
+- Avoid adding dependencies; `hack/celcost` is deliberately its own Go module to keep CEL/apiserver deps out of the root module.
+
+## Verification loop
+
+```bash
+make build-installer   # codegen up to date (catches marker/API drift)
+make fmt vet           # formatting and vet
+make lint              # golangci-lint (config in .golangci.toml); make lint-fix for autofixes
+make test-parallel     # full envtest suite
+make deadcode          # if you removed/moved exported funcs
+make lint-ui           # only if you touched ui/
+```
+
+For behavior-sensitive areas, run `make test-parallel-repeat3` to catch introduced flakiness. Commit messages / PR titles follow Conventional Commits — use `refactor:` (optionally scoped, e.g. `refactor(controller): ...`).

--- a/.claude/skills/scm-providers/SKILL.md
+++ b/.claude/skills/scm-providers/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: scm-providers
+description: Add or modify SCM provider integrations (GitHub, GitLab, Gitea, Forgejo, Bitbucket Cloud, Azure DevOps) in internal/scms/ — provider interfaces, RecordSCMCall metrics, and controller wiring. Use when touching internal/scms/ or adding support for a new SCM.
+---
+
+# SCM provider work
+
+Authoritative doc: `docs/contributing/adding-an-scm-provider.md`. Use an existing provider (e.g. `internal/scms/github/` or `internal/scms/gitea/`) as the structural template.
+
+## What a provider implements
+
+- `scms.CommitStatusProvider` (`internal/scms/commitstatus.go`) — create/update commit statuses or checks for promotion gates.
+- `scms.PullRequestProvider` (`internal/scms/pullrequest.go`) — open, update, merge, close, list PRs for change transfer.
+
+Then wire it into the controller layer: constructor selection from `ScmProvider` / `ClusterScmProvider` spec, auth secret handling, RBAC markers, and tests. `internal/scms/fake/` and `internal/scms/mock/` exist for testing.
+
+## Non-negotiable: record every SCM API call
+
+Every provider HTTP API request must call `metrics.RecordSCMCall` (`internal/metrics/metrics.go`) **exactly once per logical request**, after the call completes (success or failure). This feeds `scm_calls_total` / `scm_calls_duration_seconds` and the structured "SCM API call" debug log. Don't skip "small" calls — if it hits the REST API and counts against rate limits, record it.
+
+Pattern when the SDK exposes a response:
+
+```go
+start := time.Now()
+pr, resp, err := client.CreatePullRequest(owner, repo, opts)
+if resp != nil {
+    metrics.RecordSCMCall(ctx, gitRepo, metrics.SCMAPIPullRequest, metrics.SCMOperationCreate,
+        resp.StatusCode, time.Since(start), nil)
+}
+if err != nil {
+    return "", err // add a fallback RecordSCMCall with e.g. 500 if resp was nil
+}
+```
+
+Pattern when it doesn't (single call, both paths):
+
+```go
+start := time.Now()
+created, err := client.CreatePullRequest(ctx, args)
+statusCode := 201
+if err != nil {
+    statusCode = 500 // or map from provider-specific error
+}
+metrics.RecordSCMCall(ctx, gitRepo, metrics.SCMAPIPullRequest, metrics.SCMOperationCreate,
+    statusCode, time.Since(start), nil)
+if err != nil {
+    return "", fmt.Errorf("failed to create pull request: %w", err)
+}
+```
+
+Details:
+
+- Use the `context.Context` passed into the provider method so logging inherits reconcile fields.
+- Resolve the `GitRepository` the standard way (`utils.GetGitRepositoryFromObjectKey` or equivalent).
+- `api` is `metrics.SCMAPICommitStatus` or `metrics.SCMAPIPullRequest`; `operation` is the closest `metrics.SCMOperation` (`create`, `update`, `merge`, `close`, `list`, `get`).
+- GitHub only: pass `getRateLimitMetrics(response.Rate)` as the last arg; other providers pass `nil`.
+
+## Auth and webhooks
+
+- Credentials come from the Secret referenced by `ScmProvider`/`ClusterScmProvider` (GitHub Apps, GitLab/Forgejo/Gitea tokens, etc.); git auth plumbing is in `internal/gitauth/`, git operations in `internal/git/` (bare repos).
+- Webhook handling for real-time reconciles lives in `internal/webhookreceiver/` — a new provider usually needs its webhook event parsing added there.
+
+## Checklist for a new provider
+
+1. New package `internal/scms/<provider>/` implementing both interfaces, error-wrapping with `%w`.
+2. `RecordSCMCall` on every API round trip.
+3. Constructor wiring wherever providers are selected from the ScmProvider spec (grep for an existing provider name, e.g. `Forgejo`, to find all switch sites — API types, controllers, webhook receiver).
+4. API type update: provider config struct on `ScmProviderSpec` (follow the `crd-changes` skill; regen with `make build-installer`).
+5. Unit tests following an existing provider's tests; e2e coverage if feasible.
+6. Docs: provider setup page under `docs/`, `mkdocs.yml` entry, and update supported-provider lists (README, `docs/index.md`).

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: testing
+description: Write and run tests for GitOps Promoter — Ginkgo/Gomega envtest controller suites, e2e tests, fuzz targets, and flake checking. Use when adding tests, running the test suite, or deciding what kind of test a change needs.
+---
+
+# Testing GitOps Promoter
+
+## Running tests
+
+```bash
+make test                    # manifests + generate + fmt + vet + envtest, then all unit/controller tests
+make test-parallel           # ginkgo -p -procs=4 over internal/ (faster; what CI-style runs use)
+make test-parallel-repeat3   # parallel suite repeated to catch flakes
+make test-e2e                # e2e tests (needs a Kind cluster; go test ./test/e2e/ -v)
+make fuzz-replay             # regression-replay fuzz seeds/corpus (packages in FUZZ_PACKAGES)
+make fuzz-explore            # bounded exploratory fuzzing, FUZZ_TIME per target
+```
+
+Run a single spec:
+
+```bash
+go test -v ./internal/controller -ginkgo.focus="exact spec name" -ginkgo.v -timeout 5m 2>&1 | tail -50
+```
+
+If tests fail with "unable to find kubebuilder assets", run `make setup-envtest`. `ENVTEST_K8S_VERSION` is pinned in the Makefile.
+
+## Test conventions
+
+- **Framework**: Ginkgo/Gomega with `Describe`/`Context`/`It` blocks. Controller tests run against **envtest** (real API server, no kubelet) — see `internal/controller/suite_test.go`.
+- **Async**: anything a reconciler does is asynchronous — assert with `Eventually(...)`, never a bare `Expect` right after creating/updating an object.
+- Test files sit next to the code (`*_test.go`); controller tests are `internal/controller/<kind>_controller_controller_test.go` style, e2e lives in `test/e2e/`.
+- Use table-driven tests for multiple similar cases; test both success and error paths; clean up in `AfterEach`.
+- Mock external dependencies; mocks are generated with mockery (`make mockery-gen`), fake SCM provider lives in `internal/scms/fake/`.
+- Fake clients used with `client.MatchingFields` must register the same field indexes as the manager — follow `newFakeClientBuilder()` in `internal/apiserver/builder_test.go` and `internal/controller/fieldindex.go`.
+
+## Strict unmarshal tests for CRDs
+
+Every CRD kind has an example manifest in `internal/controller/testdata/<Kind>.yaml` (PascalCase, realistic spec **and** status) that is `go:embed`-ed into the controller test and decoded with `unmarshalYamlStrict` (`DisallowUnknownFields`). When you add or change a CRD field, update the testdata YAML or CI fails. Pattern:
+
+```go
+//go:embed testdata/<Kind>.yaml
+var test<Kind>YAML string
+
+It("should unmarshal the <Kind> resource", func() {
+    Expect(unmarshalYamlStrict(test<Kind>YAML, &promoterv1alpha1.<Kind>{})).To(Succeed())
+})
+```
+
+## Debugging failures
+
+Controller logs go to **stderr** — always capture with `2>&1` and use `-ginkgo.v`. See the `debugging` skill for the full log-capture and flake-investigation protocol.
+
+## What a change needs
+
+- New/changed CRD field → update `internal/controller/testdata/`, regen with `make build-installer`, strict unmarshal test passes, plus controller behavior tests.
+- New reconciler logic → envtest specs covering success, error, and deletion (finalizer) paths.
+- New SCM provider method → unit tests following an existing provider (e.g. `internal/scms/github/`), plus `metrics.RecordSCMCall` coverage.
+- Pure functions in `internal/utils` with parsing/sanitizing behavior → consider a fuzz target (`Fuzz*` in `fuzz_test.go`, seeds via `f.Add`).

--- a/.gitignore
+++ b/.gitignore
@@ -107,7 +107,8 @@ main
 hack/view2ts/view2ts
 hack/view2ts/dist/
 
-# Claude Code
-.claude
+# Claude Code (local settings stay untracked; shared skills are committed)
+.claude/*
+!.claude/skills/
 CLAUDE.md
 


### PR DESCRIPTION
Adds .claude/skills/ with nine skills grounded in the repo's contributing
docs and Makefile targets, and narrows the .gitignore .claude entry so
shared skills are tracked while local settings stay ignored:

- debugging: test/controller log capture protocol, finalizer and label
  debugging, common failure causes
- testing: Ginkgo/Gomega envtest conventions, make targets, strict
  unmarshal tests, fuzzing
- architecture: promotion model, CRD relationships, package map, key
  architectural rules
- refactoring: generated vs hand-written code, invariants that must
  survive refactors, verification loop
- code-review: repo-specific review checklist (codegen drift, SSA status
  rules, validation markers, SCM metrics)
- crd-changes: condensed maintaining-crds workflow incl. CEL/immutability
  marker rules
- controller-patterns: HandleReconciliationResult chokepoint, finalizer
  conventions, field indexes, RBAC markers
- scm-providers: provider interfaces, RecordSCMCall requirements, new
  provider checklist
- docs-authoring: MkDocs structure, markdown_include embeds, lint-docs

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UdRum44fqdd8MGgpfxi9fc